### PR TITLE
Fixed what appears to be a simple typo in toString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ MemoryStream.prototype.toString = MemoryStream.prototype.getAll = function() {
 		if (self._decoder) {
 			var string = self._decoder.write(data);
 			if (string.length){
-				ret += data;
+				ret += string;
 			}
 		} else {
 			ret+=data;


### PR DESCRIPTION
In presence of a decoder, toString() code was still returning raw buffer content instead of the decoded text.
