### PR TITLE
end() doesn't work if stream is in a paused state

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,41 +124,35 @@ MemoryStream.prototype.setEncoding = function(encoding) {
 
 
 MemoryStream.prototype.pause = function() {
-	if(this.readable){
+	if(this.readable || this.writable) {
 		this.paused = true;
 	}
 };
 
 MemoryStream.prototype.resume = function() {
-	if(this.readable){
-		this.paused = false;
-
-		this._next();
-	}
+	this.paused = false;
+	this._next();
 };
 
 MemoryStream.prototype.end = function(chunk, encoding) {
-
-	if (typeof chunk !== 'undefined') {
-
+	if (typeof chunk !== 'undefined')
 		this.write(chunk, encoding);
-	}
 
 	this.writable = false;
 
-	if (this.queue.length === 0) {
-
+	if (this.queue.length === 0)
 		this.readable = false;
-	}
 
 	this._emitEnd();
 };
 
 MemoryStream.prototype._emitEnd = function(){
-	if(!this._ended && !this.paused) {
-		this._ended = true;
-		this.emit('end');
-	}
+	this._ended = true;
+	if(this.paused) {
+                this.on('drain', this.emit.bind(this,'end'));
+	} else {
+                this.emit('end');
+        }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "memorystream",
+	"name": "memorystream-mcavage",
 	"description": "This is lightweight memory stream module for node.js.",
-	"version": "0.2.0",
+	"version": "0.1.0",
 	"keywords": [
 		"memory",
 		"test",
@@ -10,7 +10,6 @@
 		"streams"
 	],
 	"devDependencies" : {
-		"expresso" : ">=0.7.x",
 		"jslint" : "*"
 	},
 	"author": "Dmitry Nizovtsev (https://github.com/JSBizon)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "memorystream-mcavage",
 	"description": "This is lightweight memory stream module for node.js.",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"keywords": [
 		"memory",
 		"test",


### PR DESCRIPTION
I noticed this piping memorystream to something else. I.e., this was totally busted:

```
var ms = new MemoryStream();

ms.pause();


call_something_that_sets_up_a_pipe_async(ms);

process.nextTick(function () {
    ms.end('foo');
});
```

Where that function (in my case) was setting up a pipe _after_ it had gotten a node http client established. So the `end('data')` was long gone, and the module never emitted.
