### PR TITLE
Fixed a bug w/ pause/resume

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ MemoryStream.prototype.end = function(chunk, encoding) {
 		this.readable = false;
 	}
 	
-	this._emitEnd();
+	if (!this.queue.length) {
+		this._emitEnd();
+	}
 };
 
 MemoryStream.prototype._emitEnd = function(){


### PR DESCRIPTION
You're stream is pretty handy but I found a bug -

If the memory stream is paused when end is called then the stream will emit the 'end' event before it has finished flushing its buffers.
